### PR TITLE
fix: remove tracked targets after arSystem is paused

### DIFF
--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -249,7 +249,21 @@ class Controller {
   }
 
   stopProcessVideo() {
-    this.processingVideo = false;
+      this.processingVideo = false;
+
+      setTimeout( () => {
+          if (!this.processingVideo) {
+              for (let i = 0; i < this.trackingStates.length; i++) {
+                  const trackingState = this.trackingStates[i];
+
+                  if (trackingState.showing) {
+                      trackingState.showing = false;
+                      trackingState.trackingMatrix = null;
+                      this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: null});
+                  }
+              }
+          }
+      }, 10)
   }
 
   async detect(input) {


### PR DESCRIPTION
This PR removes the augmented content from the scene after the AR system is paused. At the moment, contents from tracked targets remain in the scene until the same target is tracked again. This is especially a problem with applications with multiple target images.