### PR TITLE
Fixed memory leaks in BuildExtremas and ComputeLocalization kernels

### DIFF
--- a/src/image-target/detector/kernels/webgl/buildExtremas.js
+++ b/src/image-target/detector/kernels/webgl/buildExtremas.js
@@ -99,7 +99,11 @@ export const buildExtremas=(args)=>{
     
     image0=engine().runKernel('DownsampleBilinear',{image:image0});
     image2=engine().runKernel('UpsampleBilinear',{image:image2,targetImage:image1});
-    return backend.runWebGLProgram(program,[image0,image1,image2],image1.dtype);
+    
+    const result= backend.runWebGLProgram(program,[image0,image1,image2],image1.dtype);
+    backend.disposeIntermediateTensorInfo(image0);
+    backend.disposeIntermediateTensorInfo(image2);
+    return result;
 }
 
 export const buildExtremasConfig = {//: KernelConfig

--- a/src/image-target/detector/kernels/webgl/computeLocalization.js
+++ b/src/image-target/detector/kernels/webgl/computeLocalization.js
@@ -50,8 +50,9 @@ export const computeLocalization=(args)=>{
 	const backend = args.backend;
 	const program = GetProgram(dogPyramidImagesT.length,prunedExtremasList.length);
 	const prunedExtremasT = tensor(prunedExtremasList, [prunedExtremasList.length, prunedExtremasList[0].length], 'int32');
-	return backend.runWebGLProgram(program, [...dogPyramidImagesT.slice(1), prunedExtremasT],dogPyramidImagesT[0].dtype);
-	 
+	const result= backend.runWebGLProgram(program, [...dogPyramidImagesT.slice(1), prunedExtremasT],dogPyramidImagesT[0].dtype);
+	backend.disposeIntermediateTensorInfo(prunedExtremasT);
+	return result;
 }
 
 export const computeLocalizationConfig = {//: KernelConfig


### PR DESCRIPTION
Added `disposeIntermediateTensorInfo` to BuildExtremas and ComputeLocalization kernels.

BuildExtremas is a bit odd, but I think what is happening is that `tidy()` is catching the original `image0`  and `image2` tensor references. And not the ones we overwrite them with since this occurs inside of a kernel function.

