### PR TITLE
Features #38 #30 #31: keep objects always visible

### DIFF
--- a/src/image-target/aframe.js
+++ b/src/image-target/aframe.js
@@ -129,8 +129,8 @@ AFRAME.registerSystem('mindar-image-system', {
 	  for (let i = 0; i < this.anchorEntities.length; i++) {
 	    if (this.anchorEntities[i].targetIndex === targetIndex) {
 	      this.anchorEntities[i].el.updateWorldMatrix(worldMatrix, targetPresent);
-	      if (worldMatrix) {
-		this.ui.hideScanning();
+	      if (worldMatrix && !this.stayVisible) {
+              this.ui.hideScanning();
 	      }
 	    }
 	  }
@@ -153,7 +153,7 @@ AFRAME.registerSystem('mindar-image-system', {
     await this.controller.dummyRun(this.video);
     this.el.emit("arReady");
     this.ui.hideLoading();
-    this.ui.showScanning();
+    if (!this.stayVisible) this.ui.showScanning();
 
     this.controller.processVideo(this.video);
   },

--- a/src/image-target/aframe.js
+++ b/src/image-target/aframe.js
@@ -124,11 +124,11 @@ AFRAME.registerSystem('mindar-image-system', {
 	  if (this.mainStats) this.mainStats.update();
 	}
 	else if (data.type === 'updateMatrix') {
-	  const {targetIndex, worldMatrix} = data;
+	  const {targetIndex, worldMatrix, targetPresent} = data;
 
 	  for (let i = 0; i < this.anchorEntities.length; i++) {
 	    if (this.anchorEntities[i].targetIndex === targetIndex) {
-	      this.anchorEntities[i].el.updateWorldMatrix(worldMatrix, );
+	      this.anchorEntities[i].el.updateWorldMatrix(worldMatrix, targetPresent);
 	      if (worldMatrix) {
 		this.ui.hideScanning();
 	      }
@@ -261,6 +261,8 @@ AFRAME.registerComponent('mindar-image-target', {
     const root = this.el.object3D;
     root.visible = false;
     root.matrixAutoUpdate = false;
+
+    this.targetPresentPrevious = false;
   },
 
   setupMarker([markerWidth, markerHeight]) {
@@ -276,11 +278,13 @@ AFRAME.registerComponent('mindar-image-target', {
     this.postMatrix.compose(position, quaternion, scale);
   },
 
-  updateWorldMatrix(worldMatrix) {
-    if (!this.el.object3D.visible && worldMatrix !== null) {
+  updateWorldMatrix(worldMatrix, targetPresent) {
+    if (this.targetPresentPrevious === false && targetPresent === true) {
       this.el.emit("targetFound");
-    } else if (this.el.object3D.visible && worldMatrix === null) {
+      this.targetPresentPrevious = true;
+    } else if (this.targetPresentPrevious === true && targetPresent === false) {
       this.el.emit("targetLost");
+      this.targetPresentPrevious = false;
     }
 
     this.el.object3D.visible = worldMatrix !== null;

--- a/src/image-target/aframe.js
+++ b/src/image-target/aframe.js
@@ -13,11 +13,13 @@ AFRAME.registerSystem('mindar-image-system', {
   tick: function() {
   },
 
-  setup: function({imageTargetSrc, maxTrack, showStats, uiLoading, uiScanning, uiError, missTolerance, warmupTolerance, filterMinCF, filterBeta}) {
+  setup: function({imageTargetSrc, maxTrack, showStats, uiLoading, uiScanning, uiError, missTolerance, warmupTolerance, filterMinCF, filterBeta, stayVisible, stayVisibleScale}) {
     this.imageTargetSrc = imageTargetSrc;
     this.maxTrack = maxTrack;
     this.filterMinCF = filterMinCF;
     this.filterBeta = filterBeta;
+    this.stayVisible = stayVisible;
+    this.stayVisibleScale = stayVisibleScale;
     this.missTolerance = missTolerance;
     this.warmupTolerance = warmupTolerance;
     this.showStats = showStats;
@@ -110,9 +112,11 @@ AFRAME.registerSystem('mindar-image-system', {
     this.controller = new Controller({
       inputWidth: video.videoWidth,
       inputHeight: video.videoHeight,
-      maxTrack: this.maxTrack, 
+      maxTrack: this.maxTrack,
       filterMinCF: this.filterMinCF,
       filterBeta: this.filterBeta,
+      stayVisible: this.stayVisible,
+      stayVisibleScale: this.stayVisibleScale,
       missTolerance: this.missTolerance,
       warmupTolerance: this.warmupTolerance,
       onUpdate: (data) => {
@@ -203,6 +207,8 @@ AFRAME.registerComponent('mindar-image', {
     filterBeta: {type: 'number', default: -1},
     missTolerance: {type: 'int', default: -1},
     warmupTolerance: {type: 'int', default: -1},
+    stayVisible: {type: 'boolean', default: false},
+    stayVisibleScale: {type: 'int', default: 50},
     showStats: {type: 'boolean', default: false},
     autoStart: {type: 'boolean', default: true},
     uiLoading: {type: 'string', default: 'yes'},
@@ -214,12 +220,14 @@ AFRAME.registerComponent('mindar-image', {
     const arSystem = this.el.sceneEl.systems['mindar-image-system'];
 
     arSystem.setup({
-      imageTargetSrc: this.data.imageTargetSrc, 
+      imageTargetSrc: this.data.imageTargetSrc,
       maxTrack: this.data.maxTrack,
       filterMinCF: this.data.filterMinCF === -1? null: this.data.filterMinCF,
       filterBeta: this.data.filterBeta === -1? null: this.data.filterBeta,
       missTolerance: this.data.missTolerance === -1? null: this.data.missTolerance,
       warmupTolerance: this.data.warmupTolerance === -1? null: this.data.warmupTolerance,
+      stayVisible: this.data.stayVisible,
+      stayVisibleScale: this.data.stayVisibleScale,
       showStats: this.data.showStats,
       uiLoading: this.data.uiLoading,
       uiScanning: this.data.uiScanning,
@@ -230,7 +238,7 @@ AFRAME.registerComponent('mindar-image', {
         arSystem.start();
       });
     }
-  },  
+  },
   remove: function () {
     const arSystem = this.el.sceneEl.systems['mindar-image-system'];
     arSystem.stop();

--- a/src/image-target/aframe.js
+++ b/src/image-target/aframe.js
@@ -262,7 +262,7 @@ AFRAME.registerComponent('mindar-image-target', {
     root.visible = false;
     root.matrixAutoUpdate = false;
 
-    this.targetPresentPrevious = false;
+    this.targetPresentBefore = false;
   },
 
   setupMarker([markerWidth, markerHeight]) {
@@ -279,12 +279,12 @@ AFRAME.registerComponent('mindar-image-target', {
   },
 
   updateWorldMatrix(worldMatrix, targetPresent) {
-    if (this.targetPresentPrevious === false && targetPresent === true) {
+    if (this.targetPresentBefore === false && targetPresent === true) {
       this.el.emit("targetFound");
-      this.targetPresentPrevious = true;
-    } else if (this.targetPresentPrevious === true && targetPresent === false) {
+      this.targetPresentBefore = true;
+    } else if (this.targetPresentBefore === true && targetPresent === false) {
       this.el.emit("targetLost");
-      this.targetPresentPrevious = false;
+      this.targetPresentBefore = false;
     }
 
     this.el.object3D.visible = worldMatrix !== null;

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -13,7 +13,7 @@ const DEFAULT_WARMUP_TOLERANCE = 5;
 const DEFAULT_MISS_TOLERANCE = 5;
 
 class Controller {
-  constructor({inputWidth, inputHeight, onUpdate=null, debugMode=false, maxTrack=1, 
+  constructor({inputWidth, inputHeight, onUpdate=null, debugMode=false, stayVisible=false, stayVisibleScale=0, maxTrack=1,
     warmupTolerance=null, missTolerance=null, filterMinCF=null, filterBeta=null}) {
 
     this.inputWidth = inputWidth;
@@ -28,6 +28,8 @@ class Controller {
     this.markerDimensions = null;
     this.onUpdate = onUpdate;
     this.debugMode = debugMode;
+    this.stayVisible = stayVisible;
+    this.stayVisibleScale = stayVisibleScale;
     this.processingVideo = false;
     this.interestedTargetIndex = -1;
     this.trackingStates = [];
@@ -173,7 +175,7 @@ class Controller {
 	  return acc + (!!s.isTracking? 1: 0);
 	}, 0);
 
-	// detect and match only if less then maxTrack
+	// detect and match only if less than maxTrack
 	if (nTracking < this.maxTrack) {
 
 	  const matchingIndexes = [];
@@ -196,11 +198,10 @@ class Controller {
 	// tracking update
 	for (let i = 0; i < this.trackingStates.length; i++) {
 	  const trackingState = this.trackingStates[i];
-
-	  if (trackingState.isTracking) {
+	  if (trackingState.isTracking && trackingState.currentModelViewTransform) {
 	    let modelViewTransform = await this._trackAndUpdate(inputT, trackingState.currentModelViewTransform, i);
 	    if (modelViewTransform === null) {
-	      trackingState.isTracking = false;
+            trackingState.isTracking = false;
 	    } else {
 	      trackingState.currentModelViewTransform = modelViewTransform;
 	    }
@@ -218,26 +219,34 @@ class Controller {
 	      }
 	    }
 	  }
-	  
+
 	  // if showing, then count miss, and hide it when reaches tolerance
 	  if (trackingState.showing) {
 	    if (!trackingState.isTracking) {
 	      trackingState.trackCount = 0;
 	      trackingState.trackMiss += 1;
-
-	      if (trackingState.trackMiss > this.missTolerance) {
-		trackingState.showing = false;
-		trackingState.trackingMatrix = null;
-		this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: null});
+	      if (trackingState.trackMiss > this.missTolerance && !this.stayVisible) {
+            trackingState.showing = false;
+            trackingState.trackingMatrix = null;
+            this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: null});
 	      }
 	    } else {
 	      trackingState.trackMiss = 0;
 	    }
 	  }
-	  
+
 	  // if showing, then call onUpdate, with world matrix
 	  if (trackingState.showing) {
-	    const worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
+          let worldMatrix;
+	      if (trackingState.trackMiss <= this.missTolerance){
+              worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
+          }
+          else {
+              const dimensions = this.markerDimensions[i];
+              worldMatrix = [
+                1, 0, 0, 0, 0, 1, 0, 0, -0, -0, 1, 0, -dimensions[0] / 2, -dimensions[1] / 2, -(dimensions[0] * dimensions[1]) / (100 + this.stayVisibleScale), 1
+              ];
+          }
 	    trackingState.trackingMatrix = trackingState.filter.filter(Date.now(), worldMatrix);
 
 	    const clone = [];
@@ -307,7 +316,7 @@ class Controller {
   _glModelViewMatrix(modelViewTransform, targetIndex) {
     const height = this.markerDimensions[targetIndex][1];
 
-    // Question: can someone verify this interpreation is correct? 
+    // Question: can someone verify this interpreation is correct?
     // I'm not very convinced, but more like trial and error and works......
     //
     // First, opengl has y coordinate system go from bottom to top, while the marker corrdinate goes from top to bottom,
@@ -318,7 +327,7 @@ class Controller {
     //    [0 -1  0  h]
     //    [0  0 -1  0]
     //    [0  0  0  1]
-    //    
+    //
     //    This is tested that if we reverse marker coordinate from bottom to top and estimate the modelViewTransform,
     //    then the above matrix is not necessary.
     //

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -236,7 +236,7 @@ class Controller {
 	  // if showing, then call onUpdate, with world matrix
 	  if (trackingState.showing) {
           let worldMatrix, targetPresent;
-	      if (trackingState.trackMiss <= this.missTolerance && trackingState.isTracking){
+	      if (trackingState.trackMiss <= this.missTolerance && trackingState.currentModelViewTransform){
               worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
               targetPresent = true;
           }

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -13,7 +13,7 @@ const DEFAULT_WARMUP_TOLERANCE = 5;
 const DEFAULT_MISS_TOLERANCE = 5;
 
 class Controller {
-  constructor({inputWidth, inputHeight, onUpdate=null, debugMode=false, stayVisible=false, stayVisibleScale=0, maxTrack=1,
+  constructor({inputWidth, inputHeight, onUpdate=null, debugMode=false, stayVisible=false, stayVisibleScale=50, maxTrack=1,
     warmupTolerance=null, missTolerance=null, filterMinCF=null, filterBeta=null}) {
 
     this.inputWidth = inputWidth;

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -235,7 +235,7 @@ class Controller {
 	  }
 	  // if showing, then call onUpdate, with world matrix
 	  if (trackingState.showing) {
-          let worldMatrix, targetPresent;
+          let worldMatrix = [], targetPresent;
 	      if (trackingState.trackMiss <= this.missTolerance && trackingState.currentModelViewTransform) {
               worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
               targetPresent = true;

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -241,9 +241,11 @@ class Controller {
               targetPresent = true;
           }
           else {
+              // if !isTracking, use "fake" worldMatrix that centers objects on the screen
               const dimensions = this.markerDimensions[i];
               worldMatrix = [
-                1, 0, 0, 0, 0, 1, 0, 0, -0, -0, 1, 0, -dimensions[0] / 2, -dimensions[1] / 2, -(dimensions[0] * dimensions[1]) / (100 + this.stayVisibleScale), 1
+                1, 0, 0, 0, 0, 1, 0, 0, -0, -0, 1, 0, -dimensions[0] / 2, -dimensions[1] / 2,
+                -(dimensions[0] * dimensions[1]) / (100 + this.stayVisibleScale), 1
               ];
               targetPresent = false;
           }

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -206,10 +206,9 @@ class Controller {
 	      trackingState.currentModelViewTransform = modelViewTransform;
 	    }
 	  }
-
 	  // if not showing, then show it once it reaches warmup number of frames
 	  if (!trackingState.showing) {
-	    if (trackingState.isTracking) {
+	    if (trackingState.isTracking || this.stayVisible) {
 	      trackingState.trackMiss = 0;
 	      trackingState.trackCount += 1;
 	      if (trackingState.trackCount > this.warmupTolerance) {
@@ -228,17 +227,16 @@ class Controller {
 	      if (trackingState.trackMiss > this.missTolerance && !this.stayVisible) {
             trackingState.showing = false;
             trackingState.trackingMatrix = null;
-            this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: null});
+            this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: null, targetPresent: false});
 	      }
 	    } else {
 	      trackingState.trackMiss = 0;
 	    }
 	  }
-
 	  // if showing, then call onUpdate, with world matrix
 	  if (trackingState.showing) {
           let worldMatrix, targetPresent;
-	      if (trackingState.trackMiss <= this.missTolerance){
+	      if (trackingState.trackMiss <= this.missTolerance && trackingState.isTracking){
               worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
               targetPresent = true;
           }

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -237,15 +237,17 @@ class Controller {
 
 	  // if showing, then call onUpdate, with world matrix
 	  if (trackingState.showing) {
-          let worldMatrix;
+          let worldMatrix, targetPresent;
 	      if (trackingState.trackMiss <= this.missTolerance){
               worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
+              targetPresent = true;
           }
           else {
               const dimensions = this.markerDimensions[i];
               worldMatrix = [
                 1, 0, 0, 0, 0, 1, 0, 0, -0, -0, 1, 0, -dimensions[0] / 2, -dimensions[1] / 2, -(dimensions[0] * dimensions[1]) / (100 + this.stayVisibleScale), 1
               ];
+              targetPresent = false;
           }
 	    trackingState.trackingMatrix = trackingState.filter.filter(Date.now(), worldMatrix);
 
@@ -253,7 +255,7 @@ class Controller {
 	    for (let j = 0; j < trackingState.trackingMatrix.length; j++) {
 	      clone[j] = trackingState.trackingMatrix[j];
 	    }
-	    this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: clone});
+	    this.onUpdate && this.onUpdate({type: 'updateMatrix', targetIndex: i, worldMatrix: clone, targetPresent: targetPresent});
 	  }
 	}
 

--- a/src/image-target/controller.js
+++ b/src/image-target/controller.js
@@ -236,12 +236,12 @@ class Controller {
 	  // if showing, then call onUpdate, with world matrix
 	  if (trackingState.showing) {
           let worldMatrix, targetPresent;
-	      if (trackingState.trackMiss <= this.missTolerance && trackingState.currentModelViewTransform){
+	      if (trackingState.trackMiss <= this.missTolerance && trackingState.currentModelViewTransform) {
               worldMatrix = this._glModelViewMatrix(trackingState.currentModelViewTransform, i);
               targetPresent = true;
           }
-          else {
-              // if !isTracking, use "fake" worldMatrix that centers objects on the screen
+          else if (this.stayVisible) {
+              // if target is not present and stayVisible is true, use "fake" worldMatrix that centers objects on the screen
               const dimensions = this.markerDimensions[i];
               worldMatrix = [
                 1, 0, 0, 0, 0, 1, 0, 0, -0, -0, 1, 0, -dimensions[0] / 2, -dimensions[1] / 2,

--- a/src/image-target/three.js
+++ b/src/image-target/three.js
@@ -32,7 +32,7 @@ export class MindARThree {
     this.renderer.outputEncoding = sRGBEncoding;
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.camera = new PerspectiveCamera();
-    this.targetPresentPrevious = false;
+    this.targetPresentBefore = false;
     this.anchors = [];
 
     this.renderer.domElement.style.position = 'absolute';
@@ -154,21 +154,21 @@ export class MindARThree {
                   this.anchors[i].group.matrix = m;
                 }
 
-                if (this.targetPresentPrevious === true && targetPresent === false) {
+                if (this.targetPresentBefore === true && targetPresent === false) {
                   this.anchors[i].visible = false;
                   console.log(this.anchors[i].onTargetFound);
                   if (this.anchors[i].onTargetLost) {
                     this.anchors[i].onTargetLost();
-                    this.targetPresentPrevious = false;
+                    this.targetPresentBefore = false;
                   }
                 }
 
-                if (!this.targetPresentPrevious === false && targetPresent === true) {
+                if (!this.targetPresentBefore === false && targetPresent === true) {
                   this.anchors[i].visible = true;
                   console.log(this.anchors[i].onTargetFound);
                   if (this.anchors[i].onTargetFound) {
                     this.anchors[i].onTargetFound();
-                    this.targetPresentPrevious = true;
+                    this.targetPresentBefore = true;
                   }
                 }
 

--- a/src/image-target/three.js
+++ b/src/image-target/three.js
@@ -156,7 +156,6 @@ export class MindARThree {
 
                 if (this.targetPresentBefore === true && targetPresent === false) {
                   this.anchors[i].visible = false;
-                  console.log(this.anchors[i].onTargetFound);
                   if (this.anchors[i].onTargetLost) {
                     this.anchors[i].onTargetLost();
                     this.targetPresentBefore = false;
@@ -165,7 +164,6 @@ export class MindARThree {
 
                 if (!this.targetPresentBefore === false && targetPresent === true) {
                   this.anchors[i].visible = true;
-                  console.log(this.anchors[i].onTargetFound);
                   if (this.anchors[i].onTargetFound) {
                     this.anchors[i].onTargetFound();
                     this.targetPresentBefore = true;

--- a/src/image-target/three.js
+++ b/src/image-target/three.js
@@ -11,13 +11,16 @@ cssScaleDownMatrix.compose(new Vector3(), new Quaternion(), new Vector3(0.001, 0
 export class MindARThree {
   constructor({
     container, imageTargetSrc, maxTrack, uiLoading = "yes", uiScanning = "yes", uiError = "yes",
-    filterMinCF = null, filterBeta = null, warmupTolerance = null, missTolerance = null
+    filterMinCF = null, filterBeta = null, warmupTolerance = null, missTolerance = null,
+    stayVisible = false, stayVisibleScale = 50,
   }) {
     this.container = container;
     this.imageTargetSrc = imageTargetSrc;
     this.maxTrack = maxTrack;
     this.filterMinCF = filterMinCF;
     this.filterBeta = filterBeta;
+    this.stayVisible = stayVisible;
+    this.stayVisibleScale = stayVisibleScale;
     this.warmupTolerance = warmupTolerance;
     this.missTolerance = missTolerance;
     this.ui = new UI({ uiLoading, uiScanning, uiError });
@@ -29,6 +32,7 @@ export class MindARThree {
     this.renderer.outputEncoding = sRGBEncoding;
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.camera = new PerspectiveCamera();
+    this.targetPresentPrevious = false;
     this.anchors = [];
 
     this.renderer.domElement.style.position = 'absolute';
@@ -121,12 +125,14 @@ export class MindARThree {
         inputHeight: video.videoHeight,
         filterMinCF: this.filterMinCF,
         filterBeta: this.filterBeta,
+        stayVisible: this.stayVisible,
+        stayVisibleScale: this.stayVisibleScale,
         warmupTolerance: this.warmupTolerance,
         missTolerance: this.missTolerance,
         maxTrack: this.maxTrack,
         onUpdate: (data) => {
           if (data.type === 'updateMatrix') {
-            const { targetIndex, worldMatrix } = data;
+            const { targetIndex, worldMatrix, targetPresent } = data;
 
             for (let i = 0; i < this.anchors.length; i++) {
               if (this.anchors[i].targetIndex === targetIndex) {
@@ -148,21 +154,25 @@ export class MindARThree {
                   this.anchors[i].group.matrix = m;
                 }
 
-                if (this.anchors[i].visible && worldMatrix === null) {
+                if (this.targetPresentPrevious === true && targetPresent === false) {
                   this.anchors[i].visible = false;
+                  console.log(this.anchors[i].onTargetFound);
                   if (this.anchors[i].onTargetLost) {
                     this.anchors[i].onTargetLost();
+                    this.targetPresentPrevious = false;
                   }
                 }
 
-                if (!this.anchors[i].visible && worldMatrix !== null) {
+                if (!this.targetPresentPrevious === false && targetPresent === true) {
                   this.anchors[i].visible = true;
+                  console.log(this.anchors[i].onTargetFound);
                   if (this.anchors[i].onTargetFound) {
                     this.anchors[i].onTargetFound();
+                    this.targetPresentPrevious = true;
                   }
                 }
 
-                if (worldMatrix !== null) {
+                if (worldMatrix !== null && !this.stayVisible) {
                   this.ui.hideScanning();
                 }
               }
@@ -193,7 +203,7 @@ export class MindARThree {
 
       await this.controller.dummyRun(this.video);
       this.ui.hideLoading();
-      this.ui.showScanning();
+      if (!this.stayVisible) this.ui.showScanning();
 
       this.controller.processVideo(this.video);
       resolve();


### PR DESCRIPTION
Features [#38](https://github.com/hiukim/mind-ar-js/issues/38) [#30](https://github.com/hiukim/mind-ar-js/issues/30) [#31](https://github.com/hiukim/mind-ar-js/issues/31): keep objects always visible

- Added stayVisible & stayVisibleScale parameters.
- If stayVisible is true, objects will remain visible in the center of the screen if target is lost and before it's first detected.
- stayVisibleScale allows you to change the scale of the object.

Not sure if you need this feature. I wrote it for my project and thought I'd suggest adding it.