### PR TITLE
fix: WebGL TensorFlow kernel cache keys

### DIFF
--- a/src/image-target/detector/kernels/webgl/binomialFilter.js
+++ b/src/image-target/detector/kernels/webgl/binomialFilter.js
@@ -8,9 +8,9 @@ const cache={};
  */
 function GetKernels(image){
   const imageWidth = image.shape[1];
-  const key = 'w' + imageWidth;
+  const imageHeight = image.shape[0];
+  const key = 'w' + imageWidth + "h" + imageHeight;
   if(!cache.hasOwnProperty(key)){
-    const imageHeight = image.shape[0];
     const kernel1 = {
       variableNames: ['p'],
       outputShape: [imageHeight, imageWidth],

--- a/src/image-target/detector/kernels/webgl/buildExtremas.js
+++ b/src/image-target/detector/kernels/webgl/buildExtremas.js
@@ -12,9 +12,9 @@ const EDGE_HESSIAN_THRESHOLD = ((EDGE_THRESHOLD+1) * (EDGE_THRESHOLD+1) / EDGE_T
 const cache={};
 function GetProgram(image){
   const imageWidth = image.shape[1];
-  const kernelKey = 'w' + imageWidth;
+  const imageHeight = image.shape[0];
+  const kernelKey = 'w' + imageWidth + "h" + imageHeight;
   if(!cache.hasOwnProperty(kernelKey)){
-    const imageHeight=image.shape[0];
     const kernel = {
       variableNames: ['image0', 'image1', 'image2'],
       outputShape: [imageHeight, imageWidth],

--- a/src/image-target/detector/kernels/webgl/downsampleBilinear.js
+++ b/src/image-target/detector/kernels/webgl/downsampleBilinear.js
@@ -5,9 +5,9 @@ const cache={};
  * @returns {GPGPUProgram}
  */
 function GetProgram(image){
-    const imageHeight = image.shape[0];
     const imageWidth = image.shape[1];
-    const kernelKey = 'w' + imageWidth;
+    const imageHeight = image.shape[0];
+    const kernelKey = 'w' + imageWidth + "h" + imageHeight;
     if(!cache.hasOwnProperty(kernelKey)){
         const kernel = {
             variableNames: ['p'],

--- a/src/image-target/detector/kernels/webgl/upsampleBilinear.js
+++ b/src/image-target/detector/kernels/webgl/upsampleBilinear.js
@@ -2,12 +2,13 @@ import {MathBackendWebGL} from '@tensorflow/tfjs-backend-webgl';
 
 const cache={};
 function GetProgram(image,targetImage){
-    const imageWidth = image.shape[1];
-    const kernelKey = 'w' + imageWidth;
+    const targetImageWidth = targetImage.shape[1];
+    const targetImageHeight = targetImage.shape[0];
+    const kernelKey = 'w' + targetImageWidth + "h" + targetImageHeight;
     if(!cache.hasOwnProperty(kernelKey)){
         const kernel = {
             variableNames: ['p'],
-            outputShape: [targetImage.shape[0], targetImage.shape[1]],
+            outputShape: [targetImageHeight, targetImageWidth],
             userCode: `
               void main() {
                 ivec2 coords = getOutputCoords();


### PR DESCRIPTION
When compiling image targets using WebGL since v1.2.0 we often get an error: `Uncaught (in promise) Error: Operands could not be broadcast together with shapes`, which is thrown by the `binomialFilter` WebGL kernel. 

We were able to fix this by updating the WebGL kernel cache keys to include both the width and height, instead of only the width. This is likely because we're using multiple images with different aspect ratios.

Fixes #339