### PR TITLE
Replace deprecated sRGBEncoding with SRGBColorSpace

### DIFF
--- a/src/face-target/three.js
+++ b/src/face-target/three.js
@@ -1,4 +1,12 @@
-import { Scene, WebGLRenderer, PerspectiveCamera, sRGBEncoding, Mesh, MeshStandardMaterial, Group } from "three";
+import {
+  Scene,
+  WebGLRenderer,
+  PerspectiveCamera,
+  SRGBColorSpace,
+  Mesh,
+  MeshStandardMaterial,
+  Group,
+} from "three";
 //import { CSS3DRenderer } from '../libs/CSS3DRenderer.js';
 import {CSS3DRenderer} from 'three/addons/renderers/CSS3DRenderer.js'
 import { Controller } from "./controller.js";
@@ -22,7 +30,7 @@ export class MindARThree {
     this.cssScene = new Scene();
     this.renderer = new WebGLRenderer({ antialias: true, alpha: true });
     this.cssRenderer = new CSS3DRenderer({ antialias: true });
-    this.renderer.outputEncoding = sRGBEncoding;
+    this.renderer.outputColorSpace = SRGBColorSpace;
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.camera = new PerspectiveCamera();
     this.userDeviceId = userDeviceId;

--- a/src/image-target/three.js
+++ b/src/image-target/three.js
@@ -1,4 +1,13 @@
-import { Matrix4, Vector3, Quaternion, Scene, WebGLRenderer, PerspectiveCamera, Group, sRGBEncoding } from "three";
+import {
+  Matrix4,
+  Vector3,
+  Quaternion,
+  Scene,
+  WebGLRenderer,
+  PerspectiveCamera,
+  Group,
+  SRGBColorSpace,
+} from "three";
 import * as tf from '@tensorflow/tfjs';
 //import { CSS3DRenderer } from '../libs/CSS3DRenderer.js';
 import {CSS3DRenderer} from 'three/addons/renderers/CSS3DRenderer.js'
@@ -33,7 +42,7 @@ export class MindARThree {
     this.cssScene = new Scene();
     this.renderer = new WebGLRenderer({ antialias: true, alpha: true });
     this.cssRenderer = new CSS3DRenderer({ antialias: true });
-    this.renderer.outputEncoding = sRGBEncoding;
+    this.renderer.outputColorSpace = SRGBColorSpace;
     this.renderer.setPixelRatio(window.devicePixelRatio);
     this.camera = new PerspectiveCamera();
     this.anchors = [];


### PR DESCRIPTION
As of r152, three stopped using sRGBEncoding and started using SRGBColorSpace instead.

This is reflected in the discussions and other various sources.

https://discourse.threejs.org/t/updates-to-color-management-in-three-js-r152/50791
![image](https://github.com/hiukim/mind-ar-js/assets/22660372/a46f56ad-5875-4e5a-b3f4-462683b9359b)

The above causes a build error when using any versions of three above r152 (currently at r162).